### PR TITLE
fix: only run when prs are created or reopened

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -6,7 +6,7 @@ const Database = require('./database')
 
 const PULL_REQUEST_EVENTS = [
   'pull_request.opened',
-  'pull_request.edited'
+  'pull_request.reopened'
 ]
 
 module.exports = robot => {


### PR DESCRIPTION
## What does this PR do?
Only watch for `opened` and `reopened` events.