### PR TITLE
feat: only run if mandatory configurations are set

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -19,6 +19,10 @@ class Config {
     return _.get(this.config, path, defaults)
   }
 
+  enabled () {
+    return this.getMinTeviewersPerPR() && this.getTeam().length
+  }
+
   getMinTeviewersPerPR () {
     return this.get('min_reviewers_per_pr', 0)
   }

--- a/src/index.js
+++ b/src/index.js
@@ -14,6 +14,11 @@ module.exports = robot => {
     context.log('prEvents', { event: context.event, action: context.payload.action })
 
     const config = new Config(context)
+
+    if (!config.enabled()) {
+      return
+    }
+
     const pullRequest = await context.github.pullRequests.get(context.issue())
     const requestedReviewers = _.get(pullRequest, 'data.requested_reviewers', [])
     const owner = _.get(pullRequest, 'data.user.login')


### PR DESCRIPTION
## What does this PR do?
Skip the repository if `min_reviewers_per_pr` or `reviewers` are not defined in `.github/pr-reviewers-bot.yml`.